### PR TITLE
[#9] Rewrite OPG/XOC README files: building-block vs composed-solution contracts

### DIFF
--- a/compositions/OPG-128/README.md
+++ b/compositions/OPG-128/README.md
@@ -1,34 +1,53 @@
 # OPG‑128 — Variants Overview
 
-This folder groups assets for the 128‑xPU training composition. We provide two network variants to align with OPG‑M exemplars and common operator preferences.
+OPG‑128 is a 128‑xPU training building block: 16 compute servers (8 xPUs each) plus
+dedicated backend and frontend leaf‑spine fabrics. It does not include an XOC spine or
+external connectivity; those are supplied when this OPG is composed into an XOC cluster.
 
-Variants
-- clos-single-homed/
-  - What it is: Matches the OPG‑M exemplar where 16 servers are single‑homed on the back‑end — 8 servers to Leaf A, 8 to Leaf B. Frontend is converged and multi‑homed.
-  - Why choose it: Clear failure isolation for maintenance (an outage on one leaf impacts only its attached 8 servers); aligns tightly with the OCP paper.
-  - Considerations: Cross‑leaf traffic traverses the spine, which can add congestion under load depending on scheduling.
+## Variants
 
-- clos-rail-optimized/
-  - What it is: Multi‑homed back‑end (L3MH) with 4×400G per leaf per server to reduce cross‑rail traffic; frontend is identical to the single‑homed variant.
-  - Why choose it: All hosts remain available at ~50% capacity during a leaf failure; when tenants are placed within a common first‑hop rail domain, most scale‑out exchanges remain leaf‑local, dramatically reducing spine traffic and associated congestion.
-  - Considerations: Benefits are strongest when scheduling keeps tenants inside an OPG.
+### Rail‑optimized backend
 
-Common attributes
-- DS5000 for 800/400/200G networks; DS3000 optional for border/ISP; DS2000 for in‑band (often single); DS1000 for OoB.
-- Port zoning: 4×200G on odd ports; 2×400G unrestricted; 32×800G uplinks per leaf reserved.
-- Optics: OS2 single‑mode DR‑class (default); distance‑friendly baseline.
+Each GPU's CX7 1×400G NIC connects to a dedicated backend rail leaf (one NIC per rail).
+The wiring pattern constrains NIC‑to‑leaf assignment by rail number, keeping intra‑rail
+connections on a single leaf. Each backend rail leaf reserves 32×800G uplinks (ports
+33–64) for XOC spine connectivity.
 
-Notes
-- Each variant folder contains: `connectivity-map.csv`, `topology-map.yaml`, `wiring/`, `diagrams/`, `netbox_inventory.json`.
+- **[clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/](clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/README.md)**
+  Air‑cooled; ~2 servers/rack
+- **[clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-liquid--dens-8srv/](clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-liquid--dens-8srv/README.md)**
+  Liquid‑cooled; ~8 servers/rack
 
-Tokenized variants (canonical for asset generation)
-- clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/
-  - Rail‑optimized Clos, CX7 1×400G per GPU, BF3 2×200G frontend, converged storage, air‑cooled; density ~2 servers/rack.
-- clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-liquid--dens-8srv/
-  - Same topology with liquid‑cooled higher density (~8 servers/rack).
-- clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/
-  - Single‑homed Clos backend; air‑cooled, ~2 servers/rack.
-- clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-liquid--dens-8srv/
-  - Single‑homed backend; liquid‑cooled, ~8 servers/rack.
+See each variant README for port budget, constraints, and composer requirements.
 
-Legacy note: The `clos-single-homed/` and `clos-rail-optimized/` folders are kept for discoverability; see the canonical tokenized variants above for assets.
+### Single‑homed backend
+
+Each server's backend NICs terminate on a single leaf (8 servers per leaf). Backend leaves
+reserve the same 32×800G uplink budget as rail‑optimized.
+
+- **[clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/](clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/README.md)**
+  Air‑cooled; ~2 servers/rack
+- **[clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-liquid--dens-8srv/](clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-liquid--dens-8srv/README.md)**
+  Liquid‑cooled; ~8 servers/rack
+
+### Comparing building‑block patterns
+
+| | Rail‑optimized | Single‑homed |
+|--|---------------|--------------|
+| NIC‑to‑leaf assignment | By rail number (predictable per GPU) | By server (each server on one leaf) |
+| Intra‑rail locality | All GPUs on rail N share a leaf | Varies by server assignment |
+| Backend leaf count | One per rail (8 leaves for 8 rails) | One per server group (2 leaves for 16 servers) |
+| Uplink budget | 32×800G per rail leaf | 32×800G per backend leaf |
+
+## Common attributes
+
+- Backend switches: DS5000 leaf + DS5000 spine (per fabric)
+- Frontend: DS5000 leaf pair (L3MH/ECMP) + DS5000 spine; converged storage/in‑band
+- OoB: DS1000
+- Port zoning: 4×200G on odd ports; 2×400G unrestricted; 32×800G uplinks per leaf reserved
+- Optics: OS2 SMF DR‑class (default)
+
+## Legacy folders
+
+`clos-rail-optimized/` and `clos-single-homed/` are kept for discoverability. Use the
+tokenized canonical variants above for all assets and generation.

--- a/compositions/OPG-128/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/README.md
+++ b/compositions/OPG-128/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/README.md
@@ -1,25 +1,39 @@
 # OPG‑128 — Rail‑Optimized Clos (CX7 1×400G, BF3 2×200G, Converged Storage, Air, 2 srv/rack)
 
-This variant applies a rail‑optimized Clos to a 128‑xPU training cluster (16 servers × 8 xPUs). Backend traffic uses CX7 1×400G per GPU; frontend/storage use BF3 2×200G per server with L3 multi‑homing.
+This building block applies a rail‑optimized Clos to a 128‑xPU training pod (16 servers × 8 xPUs). Backend traffic uses CX7 1×400G per GPU; frontend/storage use BF3 2×200G per server with L3 multi‑homing.
 
-Why choose it
-- Dramatically reduces spine traffic when multi‑node jobs are placed within a common first‑hop rail domain (rail‑n NICs on the same leaf), attacking the root cause of most performance issues (uplink/spine congestion).
-- Maintains DS5000 zoning rules for easy expansion to larger tiers.
-- Air‑cooled density for conventional racks and PDUs.
+## What this building block provides
 
-Attributes
+Rail‑optimized wiring constrains each GPU's CX7 NIC to a dedicated backend rail leaf
+(one NIC per rail, predictable switch locality per rail domain). DS5000 zoning rules are
+consistent with larger OPG tiers, supporting clean scale.
+
+## Uplink reservation
+
+Each backend rail leaf reserves ports 33–64 (32×800G) for XOC spine connectivity.
+Each frontend leaf reserves even ports 2–64 (32×800G) for XOC spine connectivity.
+These ports must not be consumed by server connections.
+
+## What a composer must supply
+
+1. XOC backend spine switches (DS5000) cabled to the 32×800G reserved ports on each
+   backend rail leaf
+2. XOC frontend spine switches (DS5000) cabled to the 32×800G reserved ports on each
+   frontend leaf
+3. External/border connectivity (DS3000 or equivalent) if WAN/ISP uplinks are required
+
+## Attributes
+
 - Backend: single plane, rail‑optimized
 - Scale‑out NICs: CX7 1×400G per GPU
 - Frontend NICs: BF3 2×200G per server (L3MH)
 - Storage: converged, 2×200G per server
 - Cooling/Density: air‑cooled; ~2 servers/rack (placeholder)
 - Optics: OS2 SMF DR‑class (default)
-- DS5000 zoning: 4×200G on odd ports; 2×400G unrestricted; 32×800G uplinks/reserved
+- DS5000 zoning: 4×200G on odd ports; 2×400G unrestricted; 32×800G uplinks reserved
 
-Scheduling note
-- Prefer packing tenants within the same first‑hop rail domain; spreading across domains forces scale‑out via the spine.
+## Assets
 
-Assets
 - `connectivity-map.csv` — end-to-end cabling and port mapping
 - `topology-map.yaml` — topology authoring plan (DS5000-based)
 - `wiring/` — Hedgehog Wiring CRDs
@@ -28,10 +42,7 @@ Assets
   - `hhfab/backend.drawio` — backend topology diagram (draw.io)
 - `netbox_inventory.json` — NetBox inventory export
 
-See also
-- Size overview: ../README.md
-- Compositions overview: ../../README.md
+## See also
 
-How to use
-- Import `netbox_inventory.json` (optional), review diagrams, then apply wiring with Hedgehog.
-- For best results, pack tenants inside a single first-hop rail domain per run.
+- Size overview: `../README.md`
+- Compositions overview: `../../README.md`

--- a/compositions/OPG-128/clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/README.md
+++ b/compositions/OPG-128/clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/README.md
@@ -1,20 +1,41 @@
 # OPG‑128 — Single‑Homed Clos (CX7 1×400G, BF3 2×200G, Converged Storage, Air, 2 srv/rack)
 
-This variant matches the single‑homed OPG‑M exemplar for the backend. Each server’s backend links terminate on one leaf (8 servers per leaf); frontend remains L3 multihomed.
+This building block applies a single‑homed Clos backend to a 128‑xPU training pod. Each
+server's backend NICs terminate on one leaf (8 servers per leaf); frontend remains L3
+multihomed.
 
-Why choose it
-- Operational simplicity and clear failure domains; aligns tightly with OPG‑M.
-- Predictable cross‑leaf behavior; good for staged adoption.
+## What this building block provides
 
-Attributes
+Single‑homed wiring assigns each server's backend NICs to a single leaf, giving clear
+per‑leaf failure domains. This matches the OPG‑M exemplar topology for the backend.
+DS5000 zoning is consistent with rail‑optimized variants at this tier.
+
+## Uplink reservation
+
+Each backend leaf reserves ports 33–64 (32×800G) for XOC spine connectivity.
+Each frontend leaf reserves even ports 2–64 (32×800G) for XOC spine connectivity.
+These ports must not be consumed by server connections.
+
+## What a composer must supply
+
+1. XOC backend spine switches (DS5000) cabled to the 32×800G reserved ports on each
+   backend leaf
+2. XOC frontend spine switches (DS5000) cabled to the 32×800G reserved ports on each
+   frontend leaf
+3. External/border connectivity (DS3000 or equivalent) if WAN/ISP uplinks are required
+
+## Attributes
+
 - Backend: single‑homed Clos (per‑server backend on one leaf)
 - Scale‑out NICs: CX7 1×400G per GPU
 - Frontend NICs: BF3 2×200G per server (L3MH)
 - Storage: converged, 2×200G per server
 - Cooling/Density: air‑cooled; ~2 servers/rack (representative)
-- Optics and zoning as per DS5000 guidance (4×200G on odd ports; 2×400G unrestricted; reserve 32×800G uplinks/leaf)
+- Optics and zoning as per DS5000 guidance (4×200G on odd ports; 2×400G unrestricted;
+  reserve 32×800G uplinks/leaf)
 
-Assets
+## Assets
+
 - `connectivity-map.csv` — end‑to‑end cabling and port mapping
 - `topology-map.yaml` — topology authoring plan (DS5000‑based)
 - `wiring/` — Hedgehog Wiring CRDs
@@ -23,10 +44,7 @@ Assets
   - `hhfab/backend.drawio` — backend topology diagram (draw.io)
 - `netbox_inventory.json` — NetBox inventory export
 
-How to use
-- Import `netbox_inventory.json` (optional), review diagrams, then apply wiring with Hedgehog.
-- Expect more leaf‑spine load than rail‑optimized when tenants span many hosts; plan scheduling accordingly.
+## See also
 
-See also
-- Size overview: ../README.md
-- Compositions overview: ../../README.md
+- Size overview: `../README.md`
+- Compositions overview: `../../README.md`

--- a/compositions/OPG-256/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/README.md
+++ b/compositions/OPG-256/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/README.md
@@ -1,6 +1,6 @@
-# OPG-256 — Clos Rail-Optimized (CX7 1x400G; BF3 2x200G; Air-Cooled; 2 srv/rack)
+# OPG-256 — Rail-Optimized Clos Building Block (CX7 1×400G; BF3 2×200G; Air-Cooled; 2 srv/rack)
 
-This composition builds a 256-xPU training cluster from 32 eight-GPU servers using a rail-optimized Clos backend fabric and a converged frontend fabric. Each GPU connects to the backend via a single ConnectX-7 400G NIC (8 NICs per server, one per rail), while each server attaches to the frontend via a BlueField-3 DPU with two 200G ports (L3MH across two leaves). Air cooling limits rack density to 2 servers per rack, spreading the 32 compute servers across 16 racks.
+This building block provides a 256-xPU rail-optimized Clos network for 32 eight-GPU servers. Each GPU connects to the backend via a single ConnectX-7 400G NIC (8 NICs per server, one per rail), while each server attaches to the frontend via a BlueField-3 DPU with two 200G ports (L3MH across two leaves). Air cooling limits rack density to 2 servers per rack, spreading the 32 compute servers across 16 racks. This OPG does not include an XOC spine; uplink ports are reserved on each leaf for XOC connectivity (see Composer requirements below).
 
 The rail-optimized wiring maps each pair of rails to a dedicated backend leaf switch, which means every backend leaf serves all 32 servers but only two of their eight GPUs. This produces the same switch count and bandwidth as a standard Clos but constrains the cabling pattern to simplify deployment and troubleshooting. The frontend fabric converges storage (NVMe-oF/RoCEv2), scale-out control-plane, and in-band management onto a single leaf-spine tier with EVPX/VXLAN isolation via Hedgehog VPCs.
 
@@ -40,6 +40,19 @@ The rail-optimized wiring maps each pair of rails to a dedicated backend leaf sw
 | Frontend spine | Celestica DS5000 | 2 | frontend |
 | OOB | Celestica DS1000-48 | 3 | oob |
 | **Total** | | **15** | |
+
+## Composer requirements
+
+To form a functional XOC cluster using this OPG, the composer must supply:
+
+1. **XOC backend spine switches** (DS5000): cable to the 32×800G reserved uplinks on each
+   backend rail leaf (ports 33–64 per switch)
+2. **XOC frontend spine switches** (DS5000): cable to the 32×800G reserved uplinks on each
+   frontend leaf (even ports 2–64 per switch)
+3. **External/border connectivity** (DS3000 or equivalent) for WAN/ISP uplinks if required
+
+Note: The Hedgehog backend controller (hh-ctrl-be) uses port E1/33 on be-leaf-01 and
+be-leaf-02, reducing those leaves' effective XOC uplink capacity from 32 to 31.
 
 ## References
 

--- a/compositions/OPG-256/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-liquid--dens-8srv/README.md
+++ b/compositions/OPG-256/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-liquid--dens-8srv/README.md
@@ -1,8 +1,8 @@
-# OPG-256 — Clos Rail-Optimized (CX7 1x400G; BF3 2x200G; Liquid-Cooled; 8 srv/rack)
+# OPG-256 — Rail-Optimized Clos Building Block (CX7 1×400G; BF3 2×200G; Liquid-Cooled; 8 srv/rack)
 
-This composition defines a 256-xPU training cluster (OPG-256) using a rail-optimized two-stage Clos backend fabric and a converged two-stage Clos frontend fabric. Thirty-two GPU servers, each equipped with 8 NVIDIA B200 GPUs and 8 CX7 single-port 400G NICs, are interconnected through 4 backend leaf switches and 4 backend spine switches (all Celestica DS5000). The frontend fabric serves 55 endpoints (32 compute, 10 storage, 10 metadata, 2 gateways, 1 controller) via 2 DS5000 leaf and 2 DS5000 spine switches. Out-of-band management uses 2 Celestica DS1000-48 switches.
+This building block provides a 256-xPU rail-optimized Clos network for 32 eight-GPU servers in a liquid-cooled configuration (8 servers per rack, 4 racks). Thirty-two GPU servers, each equipped with 8 NVIDIA B200 GPUs and 8 CX7 single-port 400G NICs, are interconnected through backend leaf switches and backend spine switches (all Celestica DS5000). The frontend fabric serves endpoints via DS5000 leaf and spine switches. Out-of-band management uses Celestica DS1000-48 switches.
 
-This is the liquid-cooled variant at 8 servers per rack (4 racks total). The network topology is identical to the air-cooled variant; only rack density and OOB peripherals (16 PDUs, 4 CDUs) differ. Choose this variant when deploying in a facility with direct liquid cooling (DLC) infrastructure and higher per-rack power density.
+The network topology is identical to the air-cooled variant; only rack density and OOB peripherals (16 PDUs, 4 CDUs) differ. This OPG does not include an XOC spine; uplink ports are reserved on each leaf for XOC connectivity.
 
 ## Assets
 
@@ -16,7 +16,7 @@ This is the liquid-cooled variant at 8 servers per rack (4 racks total). The net
 
 ## Attributes
 
-- **Composition:** OPG-256 (32 servers x 8 xPUs = 256 xPUs)
+- **Scale:** OPG-256 (32 servers × 8 xPUs = 256 xPUs)
 - **Backend:** Rail-optimized Clos; 4 DS5000 leaves, 4 DS5000 spines
 - **Frontend:** Converged Clos; 2 DS5000 leaves, 2 DS5000 spines
 - **OOB:** 2x DS1000-48 (96 ports >= 76 endpoints)
@@ -33,6 +33,16 @@ This is the liquid-cooled variant at 8 servers per rack (4 racks total). The net
 - NVIDIA B200/BF3/CX7 used as example xPU/DPU/NIC; the network design is vendor-neutral
 - Rail-optimized wiring constrains NIC-to-leaf assignment but uses the same switch count as standard Clos
 - All overlay/VPC definitions are identical between air and liquid variants
+
+## Composer requirements
+
+To form a functional XOC cluster using this OPG, the composer must supply:
+
+1. **XOC backend spine switches** (DS5000): cable to the 32×800G reserved uplinks on each
+   backend rail leaf (ports 33–64 per switch)
+2. **XOC frontend spine switches** (DS5000): cable to the 32×800G reserved uplinks on each
+   frontend leaf (even ports 2–64 per switch)
+3. **External/border connectivity** (DS3000 or equivalent) for WAN/ISP uplinks if required
 
 ## References
 

--- a/compositions/OPG-64/README.md
+++ b/compositions/OPG-64/README.md
@@ -1,44 +1,59 @@
-# OPG-64 -- Variants Overview
+# OPG-64 — Variants Overview
 
-This folder groups assets for 64-xPU training clusters. At this size we keep the
-catalog split between compact mesh-converged options and the existing rail-
-optimized Clos variant.
+OPG‑64 is a 64‑xPU training building block: 8 compute servers (8 xPUs each) plus the leaf
+switches and supporting infrastructure they attach to. It does not include a spine or
+external connectivity; those are provided by the XOC when this OPG is composed into a
+larger cluster.
 
-Available variants
-- mesh-conv-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--inb-2x25g--cooling-air--dens-2srv/
-  - What it is: Compact OPG-64 mesh-converged building block with rail-optimized
-    scale-out on a DS5000 leaf pair, plus separate `soc-storage`, `inb-mgmt`,
-    and `oob-mgmt` fabrics.
-  - Why choose it: Minimal switch count while preserving rail-aware scale-out
-    semantics and explicit management-fabric separation.
-  - Attributes
-    - Scale-out: CX7 1x400G per GPU, `rail-optimized`
-    - SoC/Storage: BF3 2x200G and storage-facing 2x200G on a two-leaf mesh
-    - In-band management: DS2000 with generic 2x25GbE NIC on every server class;
-      one port connected
-    - OOB management: DS1000 with management/BMC on every device
+## Variants
 
-- mesh-conv-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--inb-2x25g--cooling-air--dens-2srv/
-  - What it is: Same mesh-converged OPG-64 building block, but with single-homed
-    `same-switch` scale-out instead of rail-optimized scale-out.
-  - Why choose it: Operationally simpler scale-out attachment model while keeping
-    the remaining fabrics identical to the rail-optimized sibling.
-  - Attributes
-    - Scale-out: CX7 1x400G per GPU, `same-switch`
-    - SoC/Storage: BF3 2x200G and storage-facing 2x200G on a two-leaf mesh
-    - In-band management: DS2000 with generic 2x25GbE NIC on every server class;
-      one port connected
-    - OOB management: DS1000 with management/BMC on every device
-  - Consideration
-    - Final grouped-per-leaf `same-switch` realization depends on
-      `hh-netbox-plugin` issue `#322`
+### collapsed-conv--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/
 
-- clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/
-  - What it is: Rail-optimized Clos with CX7 1x400G per GPU (RDMA) and BF3
-    2x200G for converged frontend.
-  - Why choose it: Smooth path to larger OPG tiers using the same wiring rules.
+A single converged DS5000 leaf pair carries both backend (RDMA) and frontend
+(storage/in‑band) traffic. No spine is active in this building block; 32×800G uplinks
+per leaf are reserved for XOC connectivity or standalone growth. OoB via DS1000.
 
-Notes
-- Full connection maps and BOMs live inside the relevant variant folder when available.
+See [`collapsed-conv--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/README.md`](collapsed-conv--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/README.md)
+for the full building‑block spec including port budget and composer requirements.
+
+### clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/
+
+Rail‑optimized Clos with a separate backend fabric (DS5000 leaf per rail) and a converged
+frontend fabric. Each backend rail leaf has 32×800G uplinks reserved for XOC spine
+connectivity. Rail‑optimized wiring constrains each CX7 NIC to one rail leaf, producing
+predictable switch locality per rail domain.
+
+See [`clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/README.md`](clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/README.md)
+for the full building‑block spec.
+
+### mesh-conv-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--inb-2x25g--cooling-air--dens-2srv/
+
+Mesh‑converged building block with rail‑optimized scale‑out on a DS5000 leaf pair.
+Explicit fabrics for scale‑out, soc‑storage, in‑band management (DS2000, 2×25G per server),
+and OoB management (DS1000). Minimal switch count for this OPG‑64 footprint.
+
+See [`mesh-conv-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--inb-2x25g--cooling-air--dens-2srv/README.md`](mesh-conv-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--inb-2x25g--cooling-air--dens-2srv/README.md)
+for the full building‑block spec.
+
+### mesh-conv-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--inb-2x25g--cooling-air--dens-2srv/
+
+Same mesh‑converged topology as the rail‑optimized variant, but with single‑homed
+(same‑switch) scale‑out instead. Simpler NIC‑to‑leaf assignment; remaining fabrics
+(soc‑storage, inb‑mgmt, oob‑mgmt) are identical to the rail‑optimized sibling.
+
+See [`mesh-conv-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--inb-2x25g--cooling-air--dens-2srv/README.md`](mesh-conv-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--inb-2x25g--cooling-air--dens-2srv/README.md)
+for the full building‑block spec.
+
+## Common attributes
+
+- Switch family: DS5000 (800/400/200G) + DS1000 (OoB)
+- Port zoning: 4×200G breakouts on odd ports only; 2×400G unrestricted
+- Uplink budget: 32×800G per leaf, reserved for XOC spine connectivity
+- Frontend multihoming: L3MH/ECMP across two leaves (Clos variants)
+- Optics: OS2 SMF DR‑class (default)
+
+## Notes
+
+- Full connection maps and BOMs live inside each variant folder when available.
 - The legacy `converged-hyperconverged` path has been replaced by the canonical
-  tokenized `mesh-conv-*` variants.
+  tokenized `collapsed-conv` and `mesh-conv-*` variants.

--- a/compositions/OPG-64/collapsed-conv--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/README.md
+++ b/compositions/OPG-64/collapsed-conv--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/README.md
@@ -1,0 +1,83 @@
+# OPG‑64 — Collapsed Converged (CX7 1×400G, BF3 2×200G, Converged Storage, Air, 2 srv/rack)
+
+## What this building block provides
+
+A single converged leaf pair (2× DS5000) carries both the scale‑out (RDMA) backend and
+the converged frontend (storage/in‑band/management) for up to 8 compute servers (64 xPUs).
+Out‑of‑band management uses a DS1000 pair. No spine switch is active in this building
+block; the topology includes a placeholder spine pair whose uplink ports are reserved for
+future XOC connectivity or standalone growth.
+
+This is the simplest OPG topology: one managed fabric instead of two, no dedicated
+spine, and all endpoint types sharing the same leaf pair.
+
+## Fabrics
+
+- **Converged fabric** (Hedgehog‑managed): single DS5000 leaf pair carrying backend
+  (RDMA/RoCEv2), frontend (storage NVMe‑oF, in‑band, control‑plane), and storage traffic
+- **OoB fabric** (unmanaged): DS1000 pair for BMC and PDU management
+
+## Endpoint summary
+
+| Role | Count | Notes |
+|------|-------|-------|
+| Compute servers (8 xPU each) | 8 | 64 xPUs total |
+| Storage servers | 3 | Hyperconverged |
+| Metadata servers | 3 | |
+| HH gateways | 2 | |
+| HH controller | 1 | |
+
+## Port budget
+
+| Zone | Ports (per leaf) | Breakout | Logical speed | Purpose |
+|------|-----------------|---------|--------------|---------|
+| Backend server | 1–16 | 2×400G | 400G | xPU compute backend connections |
+| Converged FE | 27,29,31,33,35,37 (6 ports) | 4×200G | 200G | FE/storage/in‑band |
+| **XOC uplinks** | **26,28,30,32,34,36,38–63 (32 ports)** | **1×800G** | **800G** | **Reserved for XOC spine or expansion** |
+
+## What a composer must supply
+
+This OPG provides the leaf pair and all endpoint connections. To form a functional XOC
+cluster, the composer must supply:
+
+1. **XOC spine switches** — DS5000 (or equivalent) spine pair connected to the 32×800G
+   reserved uplink ports per leaf
+2. **Uplink cabling** — 32× OSFP-800G-DR8 cables per leaf from the reserved uplink zone
+   to the XOC spine
+3. **External/border connectivity** — DS3000 or equivalent for WAN/ISP uplinks if required
+   (out of scope for this OPG)
+
+The collapsed leaf pair can operate stand‑alone without a spine only if no external
+connectivity or cross‑OPG traffic is required. For any multi‑OPG composition or external
+egress, the XOC spine is required.
+
+## Assumptions and constraints
+
+- Port zoning: 4×200G breakouts are only valid on odd ports (27,29,31,…); 2×400G is
+  unrestricted. Violating the odd‑port rule disrupts the uplink budget.
+- The spine placeholder pair in the topology plan is not wired; post‑generation manual
+  adjustment is required to activate it.
+- 32×800G uplinks per leaf are reserved and must not be consumed by server connections.
+
+## Attributes
+
+- Backend: converged on DS5000 leaf pair (single plane)
+- Multihoming: L3MH/ECMP (HNP validation shim is eslag; RA intent is L3MH)
+- Scale‑out NICs: CX7 1×400G per GPU
+- Frontend/storage NICs: BF3 2×200G per server
+- Cooling/Density: air‑cooled; ~2 servers/rack
+- Optics: OS2 SMF DR‑class (OSFP-800G-2×400G-DR4 for backend, OSFP-800G-4×200G-DR4 for FE)
+
+## Assets
+
+- `connectivity-map.csv` — end‑to‑end cabling and port mapping
+- `topology-map.yaml` — topology authoring plan
+- `wiring/wiring-backend.yaml` — backend fabric wiring (Hedgehog CRDs)
+- `diagrams/hhfab/backend.drawio` — backend topology diagram
+- `netbox_inventory.json` — NetBox inventory export
+
+## See also
+
+- OPG‑64 overview: `../README.md`
+- Example XOC using this OPG: `../../../XOC-256/` (illustrative; not prescriptive)
+- Compositions overview: `../../../README.md`

--- a/compositions/XOC-256/2x-OPG-128/README.md
+++ b/compositions/XOC-256/2x-OPG-128/README.md
@@ -1,10 +1,40 @@
-# XOC‑256 / 1× OPG‑128 — Variants
+# XOC‑256 / 2× OPG‑128 — Bundle Overview
 
-Variants (same as OPG‑128)
-- clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/
-- clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-liquid--dens-8srv/
-- clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/
-- clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-liquid--dens-8srv/
+This bundle composes two OPG‑128 units under a shared DS5000 spine layer to form a
+256‑xPU training cluster. The XOC spine connects the uplinks from each OPG's backend
+rail‑leaf switches (backend fabric) and frontend leaf switches (frontend fabric) into a
+single converged cluster.
 
-Notes
-- See each variant folder for README and assets (to be generated).
+## What the XOC spine adds
+
+Each OPG‑128 backend rail‑leaf reserves 32×800G uplinks per switch for XOC connectivity.
+The XOC backend spine (DS5000) terminates these uplinks and provides full‑mesh ECMP
+between rail leaves across both OPG‑128 units. The XOC frontend spine provides the
+equivalent for the converged frontend fabric.
+
+Without the XOC spine, each OPG‑128 operates as an isolated 128‑xPU cluster. The spine
+is what allows cross‑OPG traffic and enables the cluster to appear as a single 256‑xPU
+fabric to schedulers and storage.
+
+## Variants
+
+All variants use the same OPG‑128 backend and frontend topology; they differ by backend
+wiring pattern (rail‑optimized vs single‑homed) and cooling/density:
+
+- [`clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/`](clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/README.md)
+  Rail‑optimized backend; air‑cooled; ~2 servers/rack
+- [`clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-liquid--dens-8srv/`](clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-liquid--dens-8srv/README.md)
+  Rail‑optimized backend; liquid‑cooled; ~8 servers/rack
+- [`clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/`](clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/README.md)
+  Single‑homed backend; air‑cooled; ~2 servers/rack
+- [`clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-liquid--dens-8srv/`](clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-liquid--dens-8srv/README.md)
+  Single‑homed backend; liquid‑cooled; ~8 servers/rack
+
+See each variant folder for the full composed‑solution guide including spine topology,
+tradeoffs, and deployment guidance.
+
+## See also
+
+- XOC‑256 tier overview: [`../README.md`](../README.md)
+- OPG‑128 building‑block specs: [`../../OPG-128/`](../../OPG-128/README.md)
+- Compositions overview: [`../../README.md`](../../README.md)

--- a/compositions/XOC-256/2x-OPG-128/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/README.md
+++ b/compositions/XOC-256/2x-OPG-128/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/README.md
@@ -1,22 +1,83 @@
-# XOC‑256 / 2× OPG‑128 — Rail‑Optimized Clos (Air)
+# XOC‑256 / 2× OPG‑128 — Rail‑Optimized Clos (CX7 1×400G, BF3 2×200G, Air, 2 srv/rack)
 
-Overview
-- Bundles two OPG‑128 building blocks with an XOC spine layer. Rail‑optimized backend plus converged frontend. With domain‑local placement, most scale‑out stays leaf‑local, materially reducing spine traffic.
+## Composed topology
 
-Attributes
-- Backend: rail‑optimized; CX7 1×400G per GPU
-- Frontend: BF3 2×200G per server (L3MH); storage converged
-- Cooling/Density: air; ~2 servers/rack
+Two OPG‑128 building blocks (16 servers each) are connected under a shared DS5000 spine
+layer to form a 256‑xPU training cluster. The XOC spine consists of DS5000 backend spine
+switches (be‑spine) and DS5000 frontend spine switches (fe‑spine).
 
-Assets
+**Backend fabric:** Each compute server connects 8 CX7 1×400G NICs to 8 dedicated backend
+rail‑leaf switches (one NIC per rail, rail‑optimized distribution). Each rail‑leaf's
+32×800G uplinks (ports 33–64) connect to the XOC backend spine, which provides full‑mesh
+ECMP across all rail leaves from both OPG‑128 units.
+
+**Frontend fabric:** Each server connects a BF3 2×200G DPU to 2 frontend leaf switches
+(L3MH/ECMP). Frontend leaf uplinks (32×800G per leaf, even ports 2–64) connect to the
+XOC frontend spine. Storage, in‑band management, and control‑plane traffic share the
+frontend fabric.
+
+**OoB:** DS1000 per OPG‑128 unit for BMC and PDU management.
+
+## Composition attributes
+
+| Attribute | Value |
+|-----------|-------|
+| Total xPUs | 256 (32 servers × 8 xPUs) |
+| Backend topology | Rail‑optimized Clos (8 rail leaves, 1 NIC/GPU/rail) |
+| Backend spine | DS5000 (XOC‑level; connects rail‑leaf uplinks across both OPG units) |
+| Frontend topology | 2‑stage Clos (FE leaves + FE spine) |
+| Cooling / Density | Air; ~2 servers/rack |
+| Scale‑out NICs | CX7 1×400G per GPU |
+| Frontend NICs | BF3 2×200G per server (L3MH) |
+
+## Why this composition
+
+OPG‑128 alone provides 128 xPUs in a single isolated cluster. Composing two OPG‑128
+units under an XOC spine doubles compute capacity to 256 xPUs while reusing the same
+wiring rules and DS5000 switch family. The rail‑optimized pattern keeps intra‑rail
+collectives leaf‑local; the XOC spine carries cross‑rail traffic that cannot be avoided
+when jobs span both OPG units.
+
+Choose this composition over 1× OPG‑256 when you want to grow incrementally (start with
+one OPG‑128 and add the second later) or when separate OPG procurement and staging is
+operationally preferred.
+
+## Tradeoffs
+
+- **Rail‑optimized backend:** jobs placed within a single OPG‑128 rail domain keep most
+  scale‑out traffic leaf‑local. Jobs spanning both OPG units generate cross‑spine traffic.
+- **Air‑cooled density:** ~2 servers/rack increases rack count and cable run distances
+  versus the liquid‑cooled variant (~8 servers/rack).
+- **DS1000 OoB is per OPG unit:** a unified OoB fabric across both units requires
+  additional planning outside this composition.
+
+## OPG‑128 building blocks
+
+This composition uses two instances of OPG‑128 clos‑ro. For the building‑block spec
+(port budget, uplink reservations, constraints), see:
+`../../../OPG-128/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/README.md`
+
+## How to use
+
+1. Deploy and validate each OPG‑128 unit independently using the OPG‑128 assets.
+2. Install XOC spine switches (be‑spine and fe‑spine, DS5000).
+3. Cable the 32×800G uplinks from each backend rail‑leaf to the be‑spine, and the
+   32×800G uplinks from each frontend leaf to the fe‑spine.
+4. Import `netbox_inventory.json` into NetBox (optional) and apply Hedgehog Wiring CRDs
+   from the `wiring/` folder.
+5. For best results, schedule multi‑node jobs within a single OPG‑128 rail domain to keep
+   most scale‑out traffic leaf‑local. Jobs that span OPG units will cross the spine.
+
+## Assets
+
 - `connectivity-map.csv` — end‑to‑end cabling and port mapping
 - `topology-map.yaml` — topology authoring plan (DS5000‑based)
 - `wiring/` — Hedgehog Wiring CRDs (per fabric)
 - `diagrams/` — visuals (per fabric)
 - `netbox_inventory.json` — NetBox inventory export
 
-Notes
- 
-See also
-- Tier overview: ../../README.md
-- Compositions overview: ../../../README.md
+## See also
+
+- Bundle overview: `../README.md`
+- OPG‑128 building blocks: `../../../OPG-128/README.md`
+- Compositions overview: `../../../README.md`

--- a/compositions/XOC-256/2x-OPG-128/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-liquid--dens-8srv/README.md
+++ b/compositions/XOC-256/2x-OPG-128/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-liquid--dens-8srv/README.md
@@ -1,23 +1,78 @@
-# XOC‑256 / 2× OPG‑128 — Rail‑Optimized Clos (Liquid)
+# XOC‑256 / 2× OPG‑128 — Rail‑Optimized Clos (CX7 1×400G, BF3 2×200G, Liquid, 8 srv/rack)
 
-Overview
-- Two OPG‑128 building blocks under an XOC spine layer. Rail‑optimized backend reduces spine load; liquid cooling enables higher rack density.
+## Composed topology
 
-Why choose it
-- Predictable scale with reduced spine congestion and higher density when liquid cooling is available.
+Two OPG‑128 building blocks (16 servers each) are connected under a shared DS5000 spine
+layer to form a 256‑xPU training cluster. The XOC spine consists of DS5000 backend spine
+switches (be‑spine) and DS5000 frontend spine switches (fe‑spine).
 
-Attributes
-- Backend: rail‑optimized; CX7 1×400G per GPU
-- Frontend: BF3 2×200G per server (L3MH)
-- Cooling/Density: liquid; ~8 servers/rack
+**Backend fabric:** Each compute server connects 8 CX7 1×400G NICs to 8 dedicated backend
+rail‑leaf switches (one NIC per rail, rail‑optimized distribution). Each rail‑leaf's
+32×800G uplinks (ports 33–64) connect to the XOC backend spine, which provides full‑mesh
+ECMP across all rail leaves from both OPG‑128 units.
 
-Assets
-- `connectivity-map.csv` — end-to-end cabling and port mapping
-- `topology-map.yaml` — topology authoring plan (DS5000-based)
-- `wiring/` — Hedgehog Wiring CRDs
-  - `wiring-backend.yaml` — backend fabric wiring
-- `diagrams/` — visual diagrams
-  - `hhfab/backend.drawio` — backend topology diagram (draw.io)
+**Frontend fabric:** Each server connects a BF3 2×200G DPU to 2 frontend leaf switches
+(L3MH/ECMP). Frontend leaf uplinks (32×800G per leaf, even ports 2–64) connect to the
+XOC frontend spine. Storage, in‑band management, and control‑plane traffic share the
+frontend fabric.
+
+**OoB:** DS1000 per OPG‑128 unit for BMC and PDU management.
+
+## Composition attributes
+
+| Attribute | Value |
+|-----------|-------|
+| Total xPUs | 256 (32 servers × 8 xPUs) |
+| Backend topology | Rail‑optimized Clos (8 rail leaves, 1 NIC/GPU/rail) |
+| Backend spine | DS5000 (XOC‑level; connects rail‑leaf uplinks across both OPG units) |
+| Frontend topology | 2‑stage Clos (FE leaves + FE spine) |
+| Cooling / Density | Liquid; ~8 servers/rack |
+| Scale‑out NICs | CX7 1×400G per GPU |
+| Frontend NICs | BF3 2×200G per server (L3MH) |
+
+## Why this composition
+
+Same rail‑optimized topology as the air‑cooled variant; liquid cooling reduces rack count
+from ~16 racks to ~4 racks and shortens cable runs. Choose this variant when deploying in
+a facility with direct liquid cooling (DLC) infrastructure and when reduced footprint or
+shorter cable distances are priorities.
+
+## Tradeoffs
+
+- **Rail‑optimized backend:** jobs placed within a single OPG‑128 rail domain keep most
+  scale‑out traffic leaf‑local. Jobs spanning both OPG units generate cross‑spine traffic.
+- **Liquid‑cooled density:** ~8 servers/rack reduces rack count and cable runs; requires
+  DLC infrastructure (CDUs) that air‑cooled deployments do not.
+- **DS1000 OoB is per OPG unit:** a unified OoB fabric across both units requires
+  additional planning outside this composition.
+
+## OPG‑128 building blocks
+
+This composition uses two instances of OPG‑128 clos‑ro. For the building‑block spec
+(port budget, uplink reservations, constraints), see:
+`../../../OPG-128/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-liquid--dens-8srv/README.md`
+
+## How to use
+
+1. Deploy and validate each OPG‑128 unit independently using the OPG‑128 assets.
+2. Install XOC spine switches (be‑spine and fe‑spine, DS5000).
+3. Cable the 32×800G uplinks from each backend rail‑leaf to the be‑spine, and the
+   32×800G uplinks from each frontend leaf to the fe‑spine.
+4. Import `netbox_inventory.json` into NetBox (optional) and apply Hedgehog Wiring CRDs
+   from the `wiring/` folder.
+5. For best results, schedule multi‑node jobs within a single OPG‑128 rail domain to keep
+   most scale‑out traffic leaf‑local. Jobs that span OPG units will cross the spine.
+
+## Assets
+
+- `connectivity-map.csv` — end‑to‑end cabling and port mapping
+- `topology-map.yaml` — topology authoring plan (DS5000‑based)
+- `wiring/` — Hedgehog Wiring CRDs (per fabric)
+- `diagrams/` — visuals (per fabric)
 - `netbox_inventory.json` — NetBox inventory export
 
-Notes
+## See also
+
+- Bundle overview: `../README.md`
+- OPG‑128 building blocks: `../../../OPG-128/README.md`
+- Compositions overview: `../../../README.md`

--- a/compositions/XOC-256/2x-OPG-128/clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/README.md
+++ b/compositions/XOC-256/2x-OPG-128/clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/README.md
@@ -1,23 +1,76 @@
-# XOC‑256 / 2× OPG‑128 — Single‑Homed Clos (Air)
+# XOC‑256 / 2× OPG‑128 — Single‑Homed Clos (CX7 1×400G, BF3 2×200G, Air, 2 srv/rack)
 
-Overview
-- Two OPG‑128 building blocks with a single‑homed backend per OPG and a converged frontend.
+## Composed topology
 
-Why choose it
-- Simpler host semantics at XOC scale; good for staged adoption when rail constraints are not desired.
+Two OPG‑128 building blocks (16 servers each) are connected under a shared DS5000 spine
+layer to form a 256‑xPU training cluster. The XOC spine consists of DS5000 backend spine
+switches (be‑spine) and DS5000 frontend spine switches (fe‑spine).
 
-Attributes
-- Backend: single‑homed; CX7 1×400G per GPU
-- Frontend: BF3 2×200G per server (L3MH)
-- Cooling/Density: air; ~2 servers/rack
+**Backend fabric:** Each server's backend NICs terminate on a single backend leaf (8 servers
+per leaf, single‑homed). Backend leaf uplinks (32×800G per leaf, ports 33–64) connect to
+the XOC backend spine.
 
-Assets
-- `connectivity-map.csv` — end-to-end cabling and port mapping
-- `topology-map.yaml` — topology authoring plan (DS5000-based)
-- `wiring/` — Hedgehog Wiring CRDs
-  - `wiring-backend.yaml` — backend fabric wiring
-- `diagrams/` — visual diagrams
-  - `hhfab/backend.drawio` — backend topology diagram (draw.io)
+**Frontend fabric:** Each server connects a BF3 2×200G DPU to 2 frontend leaf switches
+(L3MH/ECMP). Frontend leaf uplinks (32×800G per leaf, even ports 2–64) connect to the
+XOC frontend spine. Storage, in‑band management, and control‑plane traffic share the
+frontend fabric.
+
+**OoB:** DS1000 per OPG‑128 unit for BMC and PDU management.
+
+## Composition attributes
+
+| Attribute | Value |
+|-----------|-------|
+| Total xPUs | 256 (32 servers × 8 xPUs) |
+| Backend topology | Single‑homed Clos (8 servers per backend leaf) |
+| Backend spine | DS5000 (XOC‑level; connects backend leaf uplinks across both OPG units) |
+| Frontend topology | 2‑stage Clos (FE leaves + FE spine) |
+| Cooling / Density | Air; ~2 servers/rack |
+| Scale‑out NICs | CX7 1×400G per GPU |
+| Frontend NICs | BF3 2×200G per server (L3MH) |
+
+## Why this composition
+
+Single‑homed backend provides clearer per‑leaf failure domains and simpler host cabling
+than rail‑optimized (no rail‑domain constraint on NIC assignment). This aligns with the
+OPG‑M exemplar backend topology. Choose this composition when straightforward operations
+and predictable failure isolation are priorities.
+
+## Tradeoffs
+
+- **Single‑homed backend:** any job spanning servers on different backend leaves generates
+  cross‑leaf traffic via the XOC spine; there is no rail‑domain locality benefit.
+- **Simpler cabling:** NIC-to-leaf assignment is by server, not by GPU rail number.
+- **Air‑cooled density:** ~2 servers/rack increases rack count and cable run distances
+  versus the liquid‑cooled variant.
+- **DS1000 OoB is per OPG unit:** a unified OoB fabric across both units requires
+  additional planning outside this composition.
+
+## OPG‑128 building blocks
+
+This composition uses two instances of OPG‑128 clos‑sh. For the building‑block spec
+(port budget, uplink reservations, constraints), see:
+`../../../OPG-128/clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/README.md`
+
+## How to use
+
+1. Deploy and validate each OPG‑128 unit independently using the OPG‑128 assets.
+2. Install XOC spine switches (be‑spine and fe‑spine, DS5000).
+3. Cable the 32×800G uplinks from each backend leaf to the be‑spine, and the
+   32×800G uplinks from each frontend leaf to the fe‑spine.
+4. Import `netbox_inventory.json` into NetBox (optional) and apply Hedgehog Wiring CRDs
+   from the `wiring/` folder.
+
+## Assets
+
+- `connectivity-map.csv` — end‑to‑end cabling and port mapping
+- `topology-map.yaml` — topology authoring plan (DS5000‑based)
+- `wiring/` — Hedgehog Wiring CRDs (per fabric)
+- `diagrams/` — visuals (per fabric)
 - `netbox_inventory.json` — NetBox inventory export
 
-Notes
+## See also
+
+- Bundle overview: `../README.md`
+- OPG‑128 building blocks: `../../../OPG-128/README.md`
+- Compositions overview: `../../../README.md`

--- a/compositions/XOC-256/2x-OPG-128/clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-liquid--dens-8srv/README.md
+++ b/compositions/XOC-256/2x-OPG-128/clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-liquid--dens-8srv/README.md
@@ -1,19 +1,71 @@
-# XOC‑256 / 2× OPG‑128 — Single‑Homed Clos (Liquid)
+# XOC‑256 / 2× OPG‑128 — Single‑Homed Clos (CX7 1×400G, BF3 2×200G, Liquid, 8 srv/rack)
 
-Liquid‑cooled, higher density version of the single‑homed backend.
+## Composed topology
 
-Attributes
-- Backend: single‑homed; CX7 1×400G per GPU
-- Frontend: BF3 2×200G per server (L3MH)
-- Cooling/Density: liquid; ~8 servers/rack
+Two OPG‑128 building blocks (16 servers each) are connected under a shared DS5000 spine
+layer to form a 256‑xPU training cluster. Network topology is identical to the air‑cooled
+variant; only rack density and OoB peripherals differ.
 
-Assets
-- `connectivity-map.csv` — end-to-end cabling and port mapping
-- `topology-map.yaml` — topology authoring plan (DS5000-based)
-- `wiring/` — Hedgehog Wiring CRDs
-  - `wiring-backend.yaml` — backend fabric wiring
-- `diagrams/` — visual diagrams
-  - `hhfab/backend.drawio` — backend topology diagram (draw.io)
+**Backend fabric:** Single‑homed — each server's backend NICs terminate on one backend
+leaf (8 servers per leaf). Backend leaf uplinks (32×800G per leaf, ports 33–64) connect
+to the XOC backend spine (DS5000).
+
+**Frontend fabric:** BF3 2×200G per server, L3MH across two frontend leaves. Frontend
+leaf uplinks (32×800G per leaf, even ports 2–64) connect to the XOC frontend spine.
+
+**OoB:** DS1000 per OPG‑128 unit for BMC and PDU management.
+
+## Composition attributes
+
+| Attribute | Value |
+|-----------|-------|
+| Total xPUs | 256 (32 servers × 8 xPUs) |
+| Backend topology | Single‑homed Clos (8 servers per backend leaf) |
+| Backend spine | DS5000 (XOC‑level) |
+| Frontend topology | 2‑stage Clos (FE leaves + FE spine) |
+| Cooling / Density | Liquid; ~8 servers/rack |
+| Scale‑out NICs | CX7 1×400G per GPU |
+| Frontend NICs | BF3 2×200G per server (L3MH) |
+
+## Why this composition
+
+Same single‑homed topology as the air‑cooled variant; liquid cooling reduces rack count
+from ~16 racks to ~4 racks and shortens cable runs. Choose this variant when straightforward
+operations, predictable failure isolation, and a compact liquid‑cooled footprint are all
+priorities.
+
+## Tradeoffs
+
+- **Single‑homed backend:** any job spanning servers on different backend leaves generates
+  cross‑spine traffic; no rail‑domain locality benefit.
+- **Liquid‑cooled density:** ~8 servers/rack reduces footprint; requires DLC infrastructure
+  (CDUs).
+- **DS1000 OoB is per OPG unit.**
+
+## OPG‑128 building blocks
+
+This composition uses two instances of OPG‑128 clos‑sh. For the building‑block spec, see:
+`../../../OPG-128/clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-liquid--dens-8srv/README.md`
+
+## How to use
+
+1. Deploy and validate each OPG‑128 unit independently.
+2. Install XOC spine switches (be‑spine and fe‑spine, DS5000).
+3. Cable the 32×800G uplinks from each backend leaf to the be‑spine, and the
+   32×800G uplinks from each frontend leaf to the fe‑spine.
+4. Import `netbox_inventory.json` into NetBox (optional) and apply Hedgehog Wiring CRDs
+   from the `wiring/` folder.
+
+## Assets
+
+- `connectivity-map.csv` — end‑to‑end cabling and port mapping
+- `topology-map.yaml` — topology authoring plan (DS5000‑based)
+- `wiring/` — Hedgehog Wiring CRDs (per fabric)
+- `diagrams/` — visuals (per fabric)
 - `netbox_inventory.json` — NetBox inventory export
 
-Notes
+## See also
+
+- Bundle overview: `../README.md`
+- OPG‑128 building blocks: `../../../OPG-128/README.md`
+- Compositions overview: `../../../README.md`

--- a/compositions/XOC-512/1x-OPG-512/README.md
+++ b/compositions/XOC-512/1x-OPG-512/README.md
@@ -1,10 +1,24 @@
-# XOC‑512 / 1× OPG‑512 — Variants
+# XOC‑512 / 1× OPG‑512 — Bundle Overview
 
-Variants
-- clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/
-- clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-liquid--dens-8srv/
-- dual-plane--cx8-2x400g--bf3-2x200g--2p--storage-conv-2x200g--cooling-air--dens-2srv/
-- dual-plane--cx8-2x400g--bf3-2x200g--2p--storage-conv-2x200g--cooling-liquid--dens-8srv/
+This bundle places a single OPG‑512 unit under an XOC spine layer to form a 512‑xPU
+cluster. The XOC spine (DS5000) connects the uplinks from the OPG‑512 backend rail‑leaf
+and frontend leaf switches, providing cross‑fabric ECMP and external egress that the
+OPG‑512 building block does not supply on its own.
 
-Notes
-- See each variant folder for README and assets (to be generated).
+## Variants
+
+- [`clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/`](clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/README.md)
+  Rail‑optimized backend; air‑cooled; ~2 servers/rack
+- [`clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-liquid--dens-8srv/`](clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-liquid--dens-8srv/README.md)
+  Rail‑optimized backend; liquid‑cooled; ~8 servers/rack
+- [`dual-plane--cx8-2x400g--bf3-2x200g--2p--storage-conv-2x200g--cooling-air--dens-2srv/`](dual-plane--cx8-2x400g--bf3-2x200g--2p--storage-conv-2x200g--cooling-air--dens-2srv/README.md)
+  Dual‑plane backend (CX8 2×400G); air‑cooled; ~2 servers/rack
+- [`dual-plane--cx8-2x400g--bf3-2x200g--2p--storage-conv-2x200g--cooling-liquid--dens-8srv/`](dual-plane--cx8-2x400g--bf3-2x200g--2p--storage-conv-2x200g--cooling-liquid--dens-8srv/README.md)
+  Dual‑plane backend (CX8 2×400G); liquid‑cooled; ~8 servers/rack
+
+See each variant folder for the full composed‑solution guide.
+
+## See also
+
+- XOC‑512 tier overview: [`../../README.md`](../../README.md)
+- OPG‑512 building‑block specs: [`../../../OPG-512/`](../../../OPG-512/README.md)

--- a/compositions/XOC-512/4x-OPG-128/README.md
+++ b/compositions/XOC-512/4x-OPG-128/README.md
@@ -1,11 +1,24 @@
 # XOC‑512 — 4× OPG‑128
 
-Cluster composed of four OPG‑128 units behind a DS5000 spine layer. Scheduling guidance encourages keeping tenants within an OPG to reduce spine traffic. Frontend per OPG is converged; OoB per OPG via DS1000.
+Four OPG‑128 units (16 servers each) are connected behind a shared DS5000 spine layer to
+form a 512‑xPU cluster. The XOC spine (DS5000) terminates the 32×800G uplinks from each
+OPG's backend rail‑leaf and frontend leaf switches, providing cross‑OPG ECMP and external
+egress.
 
-Assets (to be added):
-- connectivity-map.csv
-- bom.yaml
-- wiring.yaml (per OPG + spine)
-- vpc.yaml
-- diagrams/
+## Variants
 
+- [`clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/`](clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/README.md)
+  Rail‑optimized backend; air‑cooled; ~2 servers/rack
+- [`clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-liquid--dens-8srv/`](clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-liquid--dens-8srv/README.md)
+  Rail‑optimized backend; liquid‑cooled; ~8 servers/rack
+- [`clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/`](clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-air--dens-2srv/README.md)
+  Single‑homed backend; air‑cooled; ~2 servers/rack
+- [`clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-liquid--dens-8srv/`](clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--cooling-liquid--dens-8srv/README.md)
+  Single‑homed backend; liquid‑cooled; ~8 servers/rack
+
+For the sub‑bundle structure see [`2x-OPG-128/`](2x-OPG-128/README.md).
+
+## See also
+
+- XOC‑512 tier overview: [`../../README.md`](../../README.md)
+- OPG‑128 building‑block specs: [`../../../OPG-128/`](../../../OPG-128/README.md)

--- a/docs/COMPOSITION_VARIANT_NAMING_TAXONOMY.md
+++ b/docs/COMPOSITION_VARIANT_NAMING_TAXONOMY.md
@@ -52,3 +52,108 @@ Tasks
 
 Acceptance Criteria
 - Naming taxonomy is accepted and applied to new folders/variants; guidance added to RA_REPOS/CONTRIBUTING.md.
+
+---
+
+## README Content Contract by Layer
+
+This section defines what each README layer in the OPG/XOC composition hierarchy is
+responsible for. It supplements the naming-token guidance above. Authors adding new OPG
+or XOC variants should follow both the naming convention above and the content contract
+for their layer.
+
+### Layer definitions and content contracts
+
+**Layer 1 — `compositions/README.md` (top-level index)**
+
+Required: OPG/XOC definitions; folder organization; navigation guidance.
+
+Key framing: OPGs are *incomplete building blocks* — they include servers and leaf
+switches but do not include a spine or external connectivity. XOCs are *composed
+solutions* that add spine/aggregation and external connectivity over one or more OPGs.
+
+---
+
+**Layer 2 — `OPG-*/README.md` (size overview)**
+
+Required: Variant list with building-block summaries; common attributes including
+uplink budget; pointer to variant READMEs.
+
+Prohibited: Deployment instructions; "why choose it" framed as a deployment decision;
+scheduling guidance for deployed clusters.
+
+---
+
+**Layer 3 — `OPG-*/<variant>/README.md` (building-block spec)**
+
+Required:
+- What this OPG provides: topology pattern, fabrics (backend/frontend/OoB), hardware
+- Port budget: server downlink zones and uplink zone with port count, speed
+- Uplink reservation: explicitly state "N×Y uplinks are reserved per leaf for XOC
+  spine connectivity" — this is the interface exposed to the composer
+- What a composer must supply: list the XOC spine switches, uplink cabling, and any
+  external connectivity that this OPG does not include
+- Assumptions and constraints: port zoning rules and topology-specific constraints
+- Assets list
+
+Optional: Reference to example XOC compositions using this variant, labeled as
+illustrative only (not prescriptive).
+
+Prohibited:
+- "How to use" deployment steps (import netbox_inventory.json, apply wiring CRDs,
+  use Hedgehog in a lab)
+- "Ideal for pilots/edge/first deployments" framing
+- Scheduling guidance for deployed clusters (tenant placement, rail-domain locality)
+- "composition/cluster" as the framing noun for the OPG itself
+- Prescribing how the OPG must be composed
+
+---
+
+**Layer 4 — `XOC-*/README.md` (tier overview)**
+
+Required: What this XOC tier composes (total xPU scale); available bundles; operator
+benefits; brief mention of what the spine/aggregation layer adds.
+
+---
+
+**Layer 5a — `XOC-*/<bundle>/README.md` (bundle)**
+
+Required: What the bundle composes (N× OPG-X under spine); what the XOC spine
+adds at this bundle scale; variant list with one-line descriptions; links to variant READMEs.
+
+Prohibited: Content-free bare variant lists with no explanation.
+
+---
+
+**Layer 5b — `XOC-*/<bundle>/<variant>/README.md` (composed-solution guide)**
+
+Required:
+- Composed topology: which OPGs, how they connect to the spine, total cluster scale
+- Spine/aggregation layer description: switch model, role, how OPG uplinks connect
+- Composition-level attributes (full cluster scale, cross-OPG traffic characteristics)
+- Why this composition exists: what it achieves that an OPG alone cannot; tradeoffs
+  vs alternatives at the same tier
+- Brief OPG summary (1-2 sentences) with pointer to OPG docs for building-block detail
+- Deployment guidance ("How to use") — this belongs here, not in OPG READMEs
+- Assets list
+
+Prohibited: Re-describing OPG building-block detail at length (defer to OPG docs).
+
+---
+
+### Cross-reference rules
+
+- OPG READMEs may reference example XOC compositions — labeled as illustrative only,
+  never as the defining purpose of the OPG.
+- XOC READMEs must briefly summarize constituent OPGs and point to OPG docs for
+  building-block detail.
+- "How to use" / deployment steps and scheduling guidance belong exclusively in
+  Layer 5b (XOC variant READMEs).
+
+### Sub-bundle navigation stubs
+
+If a bundle directory contains a sub-bundle directory (e.g.,
+`XOC-512/4x-OPG-128/2x-OPG-128/`), its README is a *navigation stub*: 1-2 sentences
+describing what the sub-grouping represents, plus a variant list. Full Layer 5a content
+is not required until the folder structure is confirmed as intentional.
+


### PR DESCRIPTION
Replaces #15, which had an incorrect base branch.

## Summary

Applies the five-layer README content contract from Phase 1–3 of #9. Branch based directly on `main`; diff is README files and taxonomy doc only.

- **OPG READMEs (Layers 2–3):** Reframed as building-block specs — explicit uplink reservation for XOC spine, "What a composer must supply," no deployment steps, no scheduling guidance.
- **XOC variant READMEs (Layer 5b):** Full composed-solution guides — composed topology, spine description, "Why this composition," tradeoffs, OPG pointer, "How to use" deployment steps.
- **XOC bundle READMEs (Layers 4–5a):** Written where previously missing or content-free (XOC-256/2x-OPG-128, XOC-512/1x-OPG-512, XOC-512/4x-OPG-128 updated).
- **OPG-64/README.md:** Conflict resolved — all four variants (collapsed-conv, clos-ro, mesh-conv-ro, mesh-conv-sh) included with building-block framing.
- **Taxonomy doc:** "README Content Contract by Layer" section added.

## Files changed (15 — README.md and taxonomy doc only)

```
compositions/OPG-64/README.md
compositions/OPG-64/collapsed-conv--…/README.md  (new)
compositions/OPG-128/README.md
compositions/OPG-128/clos-ro--…/README.md
compositions/OPG-128/clos-sh--…/README.md
compositions/OPG-256/clos-ro--…-air/README.md
compositions/OPG-256/clos-ro--…-liquid/README.md
compositions/XOC-256/2x-OPG-128/README.md
compositions/XOC-256/2x-OPG-128/clos-ro--…-air/README.md
compositions/XOC-256/2x-OPG-128/clos-ro--…-liquid/README.md
compositions/XOC-256/2x-OPG-128/clos-sh--…-air/README.md
compositions/XOC-256/2x-OPG-128/clos-sh--…-liquid/README.md
compositions/XOC-512/1x-OPG-512/README.md
compositions/XOC-512/4x-OPG-128/README.md
docs/COMPOSITION_VARIANT_NAMING_TAXONOMY.md
```

No asset files, no topology-map edits, no generated artifact changes.

Closes #14. Supersedes #15.
Related: #9, #10, #11, #12, #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)