### PR TITLE
Docs: add collapsed-conv to composition quick key

### DIFF
--- a/compositions/README.md
+++ b/compositions/README.md
@@ -29,7 +29,7 @@ Picking a starting point
 - Prefer rail‑optimized variants for training workloads when possible; it can reduce spine traffic and improve job throughput.
 
 Reading the variant names (quick key)
-- Topology: `clos-sh` (single‑homed), `clos-ro` (rail‑optimized), `dual-plane` (two independent planes)
+- Topology: `clos-sh` (single‑homed), `clos-ro` (rail‑optimized), `dual-plane` (two independent planes), `collapsed-conv` (collapsed converged leaf pair)
 - Scale‑out NICs: `cx7-1x400g`, `cx8-2x400g`, `cx9-1x800g`
 - Frontend NICs: `bf3-2x200g` (or vendor‑neutral `fe-2x200g`)
 - Planes: `1p` or `2p`


### PR DESCRIPTION
One-line fix: adds `collapsed-conv` to the topology token quick key in `compositions/README.md`.

`collapsed-conv` is now a live variant token on main (OPG-64, merged in #17/#18) but was not listed in the quick-key reference at the top of the compositions index.

## Diff

```
-  Topology: `clos-sh`, `clos-ro`, `dual-plane`
+  Topology: `clos-sh`, `clos-ro`, `dual-plane`, `collapsed-conv` (collapsed converged leaf pair)
```

One file, one line. No asset changes, no README rewrites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)