### PR TITLE
Remove density tokens from composition names, case IDs, and docs

### DIFF
--- a/compositions/OPG-128/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/netbox_inventory.json
+++ b/compositions/OPG-128/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/netbox_inventory.json
@@ -18022,7 +18022,7 @@
     },
     "generated_at": "2026-03-14T01:36:24.719783+00:00",
     "plan_id": 49,
-    "plan_name": "Training OPG-128 Clos RO Air 2srv"
+    "plan_name": "Training OPG-128 Clos RO"
   },
   "modules": [
     {

--- a/compositions/OPG-128/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/topology-map.yaml
+++ b/compositions/OPG-128/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/topology-map.yaml
@@ -1,5 +1,5 @@
 meta:
-  case_id: training_opg128_clos_ro_air_2srv
+  case_id: training_opg128_clos_ro
   name: Training OPG-128 Clos RO
   description: Compute-only DIET translation for the OPG-128 rail-optimized training RA
   version: 1

--- a/compositions/OPG-128/clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/netbox_inventory.json
+++ b/compositions/OPG-128/clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/netbox_inventory.json
@@ -18022,7 +18022,7 @@
     },
     "generated_at": "2026-03-14T01:42:06.395075+00:00",
     "plan_id": 50,
-    "plan_name": "Training OPG-128 Clos SH Air 2srv"
+    "plan_name": "Training OPG-128 Clos SH"
   },
   "modules": [
     {

--- a/compositions/OPG-128/clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/topology-map.yaml
+++ b/compositions/OPG-128/clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/topology-map.yaml
@@ -1,5 +1,5 @@
 meta:
-  case_id: training_opg128_clos_sh_air_2srv
+  case_id: training_opg128_clos_sh
   name: Training OPG-128 Clos SH
   description: Compute-only DIET translation for the OPG-128 single-homed training RA
   version: 1

--- a/compositions/OPG-256/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/diagrams/topology-overview.md
+++ b/compositions/OPG-256/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/diagrams/topology-overview.md
@@ -173,7 +173,6 @@ Odd ports with 4x200G breakout, endpoints assigned sequentially:
   │ 4xPDU│   │ 4xPDU│   │ 4xPDU│       │ 4xPDU│
   └──────┘   └──────┘   └──────┘       └──────┘
 
-  2 servers per rack = 16 racks for 32 compute servers
   4 PDUs per rack = 64 PDUs total (managed via OOB)
 
   Additional racks for switches, storage, metadata, gateways,

--- a/compositions/OPG-256/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/netbox_inventory.json
+++ b/compositions/OPG-256/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/netbox_inventory.json
@@ -31554,7 +31554,7 @@
     },
     "generated_at": "2026-03-14T01:50:24.970741+00:00",
     "plan_id": 51,
-    "plan_name": "Training OPG-256 Clos RO Air 2srv"
+    "plan_name": "Training OPG-256 Clos RO"
   },
   "modules": [
     {

--- a/compositions/OPG-256/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/topology-map.yaml
+++ b/compositions/OPG-256/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/topology-map.yaml
@@ -1,5 +1,5 @@
 meta:
-  case_id: training_opg256_clos_ro_air_2srv
+  case_id: training_opg256_clos_ro
   name: Training OPG-256 Clos RO
   description: Compute-only DIET translation for the OPG-256 rail-optimized training RA
   version: 1

--- a/compositions/OPG-256/dual-plane--cx8-2x400g--bf3-2x200g--2p--storage-conv-2x200g/netbox_inventory.json
+++ b/compositions/OPG-256/dual-plane--cx8-2x400g--bf3-2x200g--2p--storage-conv-2x200g/netbox_inventory.json
@@ -54586,7 +54586,7 @@
     },
     "generated_at": "2026-03-14T02:02:44.024600+00:00",
     "plan_id": 52,
-    "plan_name": "Training OPG-256 Dual Plane Air 2srv"
+    "plan_name": "Training OPG-256 Dual Plane"
   },
   "modules": [
     {

--- a/compositions/OPG-256/dual-plane--cx8-2x400g--bf3-2x200g--2p--storage-conv-2x200g/topology-map.yaml
+++ b/compositions/OPG-256/dual-plane--cx8-2x400g--bf3-2x200g--2p--storage-conv-2x200g/topology-map.yaml
@@ -1,5 +1,5 @@
 meta:
-  case_id: training_opg256_dual_plane_air_2srv
+  case_id: training_opg256_dual_plane
   name: Training OPG-256 Dual Plane
   description: Compute-only DIET translation for the OPG-256 dual-plane training RA
   version: 1

--- a/compositions/OPG-512/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/netbox_inventory.json
+++ b/compositions/OPG-512/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/netbox_inventory.json
@@ -58618,7 +58618,7 @@
     },
     "generated_at": "2026-03-14T03:09:06.629528+00:00",
     "plan_id": 60,
-    "plan_name": "Training OPG-512 Clos RO Air 2srv"
+    "plan_name": "Training OPG-512 Clos RO"
   },
   "modules": [
     {

--- a/compositions/OPG-512/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/topology-map.yaml
+++ b/compositions/OPG-512/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/topology-map.yaml
@@ -1,5 +1,5 @@
 meta:
-  case_id: training_opg512_clos_ro_air_2srv
+  case_id: training_opg512_clos_ro
   name: Training OPG-512 Clos RO
   description: Compute-only DIET translation for the OPG-512 rail-optimized training RA
   version: 1

--- a/compositions/OPG-512/dual-plane--cx8-2x400g--bf3-2x200g--2p--storage-conv-2x200g/netbox_inventory.json
+++ b/compositions/OPG-512/dual-plane--cx8-2x400g--bf3-2x200g--2p--storage-conv-2x200g/netbox_inventory.json
@@ -104682,7 +104682,7 @@
     },
     "generated_at": "2026-03-14T03:31:30.467611+00:00",
     "plan_id": 61,
-    "plan_name": "Training OPG-512 Dual Plane Air 2srv"
+    "plan_name": "Training OPG-512 Dual Plane"
   },
   "modules": [
     {

--- a/compositions/OPG-512/dual-plane--cx8-2x400g--bf3-2x200g--2p--storage-conv-2x200g/topology-map.yaml
+++ b/compositions/OPG-512/dual-plane--cx8-2x400g--bf3-2x200g--2p--storage-conv-2x200g/topology-map.yaml
@@ -1,5 +1,5 @@
 meta:
-  case_id: training_opg512_dual_plane_air_2srv
+  case_id: training_opg512_dual_plane
   name: Training OPG-512 Dual Plane
   description: Compute-only DIET translation for the OPG-512 dual-plane training RA
   version: 1

--- a/compositions/OPG-64/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/generated/inputs/training_opg64_clos_ro.yaml
+++ b/compositions/OPG-64/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/generated/inputs/training_opg64_clos_ro.yaml
@@ -1,6 +1,6 @@
 meta:
-  case_id: training_opg64_clos_ro_air_2srv
-  name: Training OPG-64 Clos RO Air 2srv
+  case_id: training_opg64_clos_ro
+  name: Training OPG-64 Clos RO
   description: Compute-only DIET translation for the OPG-64 rail-optimized air-cooled training RA
   version: 1
   managed_by: yaml
@@ -212,7 +212,7 @@ reference_data:
           type: other
 
 plan:
-  name: Training OPG-64 Clos RO Air 2srv
+  name: Training OPG-64 Clos RO
   status: draft
   description: Compute-only DIET translation of the OPG-64 rail-optimized air-cooled training reference architecture. Non-compute endpoint counts remain intentionally excluded pending source confirmation.
 

--- a/compositions/OPG-64/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/generated/inputs/translation-notes.md
+++ b/compositions/OPG-64/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/generated/inputs/translation-notes.md
@@ -1,4 +1,4 @@
-# Translation Notes: training_opg64_clos_ro_air_2srv
+# Translation Notes: training_opg64_clos_ro
 
 ## Pass-1 Status: complete-pass1
 

--- a/compositions/OPG-64/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/generated/netbox/plan_inventory.json
+++ b/compositions/OPG-64/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/generated/netbox/plan_inventory.json
@@ -11618,7 +11618,7 @@
     },
     "generated_at": "2026-03-14T01:31:09.696365+00:00",
     "plan_id": 48,
-    "plan_name": "Training OPG-64 Clos RO Air 2srv"
+    "plan_name": "Training OPG-64 Clos RO"
   },
   "modules": [
     {

--- a/compositions/OPG-64/collapsed-conv--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/netbox_inventory.json
+++ b/compositions/OPG-64/collapsed-conv--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/netbox_inventory.json
@@ -10679,7 +10679,7 @@
     },
     "generated_at": "2026-03-13T17:59:57.642466+00:00",
     "plan_id": 30,
-    "plan_name": "Training OPG-64 Collapsed Converged Air 2srv"
+    "plan_name": "Training OPG-64 Collapsed Converged"
   },
   "modules": [
     {

--- a/compositions/OPG-64/collapsed-conv--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/topology-map.yaml
+++ b/compositions/OPG-64/collapsed-conv--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/topology-map.yaml
@@ -1,5 +1,5 @@
 meta:
-  case_id: training_opg64_collapsed_conv_air_2srv
+  case_id: training_opg64_collapsed_conv
   name: Training OPG-64 Collapsed Converged
   description: Reference-architecture intake case for the OPG-64 collapsed-converged training topology
   version: 1

--- a/compositions/OPG-64/mesh-conv-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--inb-2x25g/topology-map.yaml
+++ b/compositions/OPG-64/mesh-conv-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--inb-2x25g/topology-map.yaml
@@ -1,5 +1,5 @@
 meta:
-  case_id: opg64_mesh_conv_ro_air_2srv
+  case_id: opg64_mesh_conv_ro
   name: OPG-64 Mesh Converged RO
   description: Reference-architecture intake case for OPG-64 mesh-converged training topology with rail-optimized scale-out on a shared SoC/storage/scale-out DS5000 mesh pair
   version: 1

--- a/compositions/OPG-64/mesh-conv-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--inb-2x25g/topology-map.yaml
+++ b/compositions/OPG-64/mesh-conv-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--inb-2x25g/topology-map.yaml
@@ -1,5 +1,5 @@
 meta:
-  case_id: opg64_mesh_conv_sh_air_2srv
+  case_id: opg64_mesh_conv_sh
   name: OPG-64 Mesh Converged SH
   description: Reference-architecture intake case for OPG-64 mesh-converged training topology with single-homed scale-out on a shared SoC/storage/scale-out DS5000 mesh pair
   version: 1

--- a/compositions/README.md
+++ b/compositions/README.md
@@ -35,7 +35,7 @@ Reading the variant names (quick key)
 - Planes: `1p` or `2p`
 - Storage links: `storage-conv-<links>x<speed>` or `storage-ded-<links>x<speed>`
 
-Cooling and density
+Cooling
 - The compositions in this repository are designed to work with air or liquid cooling at any density. Cooling medium and rack density are physical deployment choices that do not affect the network topology.
 
 A note on completeness

--- a/compositions/XOC-1024/2x-OPG-512/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/topology-map.yaml
+++ b/compositions/XOC-1024/2x-OPG-512/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/topology-map.yaml
@@ -1,5 +1,5 @@
 meta:
-  case_id: training_xoc1024_2xopg512_clos_ro_air_2srv
+  case_id: training_xoc1024_2xopg512_clos_ro
   name: Training XOC-1024 2x OPG-512 Clos RO
   description: Compute-only DIET translation for the XOC-1024 (2x OPG-512) rail-optimized training RA
   version: 1

--- a/compositions/XOC-1024/2x-OPG-512/dual-plane--cx8-2x400g--bf3-2x200g--2p--storage-conv-2x200g/topology-map.yaml
+++ b/compositions/XOC-1024/2x-OPG-512/dual-plane--cx8-2x400g--bf3-2x200g--2p--storage-conv-2x200g/topology-map.yaml
@@ -1,5 +1,5 @@
 meta:
-  case_id: training_xoc1024_2xopg512_dual_plane_air_2srv
+  case_id: training_xoc1024_2xopg512_dual_plane
   name: Training XOC-1024 2x OPG-512 Dual Plane
   description: Compute-only DIET translation for the XOC-1024 (2x OPG-512) dual-plane training RA
   version: 1

--- a/compositions/XOC-256/2x-OPG-128/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/netbox_inventory.json
+++ b/compositions/XOC-256/2x-OPG-128/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/netbox_inventory.json
@@ -31554,7 +31554,7 @@
     },
     "generated_at": "2026-03-14T04:29:09.157378+00:00",
     "plan_id": 64,
-    "plan_name": "Training XOC-256 2x OPG-128 Clos RO Air 2srv"
+    "plan_name": "Training XOC-256 2x OPG-128 Clos RO"
   },
   "modules": [
     {

--- a/compositions/XOC-256/2x-OPG-128/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/topology-map.yaml
+++ b/compositions/XOC-256/2x-OPG-128/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/topology-map.yaml
@@ -1,5 +1,5 @@
 meta:
-  case_id: training_xoc256_2xopg128_clos_ro_air_2srv
+  case_id: training_xoc256_2xopg128_clos_ro
   name: Training XOC-256 2x OPG-128 Clos RO
   description: Compute-only DIET translation for the XOC-256 (2x OPG-128) rail-optimized training RA
   version: 1

--- a/compositions/XOC-256/2x-OPG-128/clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/netbox_inventory.json
+++ b/compositions/XOC-256/2x-OPG-128/clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/netbox_inventory.json
@@ -31554,7 +31554,7 @@
     },
     "generated_at": "2026-03-14T04:38:32.241341+00:00",
     "plan_id": 65,
-    "plan_name": "Training XOC-256 2x OPG-128 Clos SH Air 2srv"
+    "plan_name": "Training XOC-256 2x OPG-128 Clos SH"
   },
   "modules": [
     {

--- a/compositions/XOC-256/2x-OPG-128/clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/topology-map.yaml
+++ b/compositions/XOC-256/2x-OPG-128/clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/topology-map.yaml
@@ -1,5 +1,5 @@
 meta:
-  case_id: training_xoc256_2xopg128_clos_sh_air_2srv
+  case_id: training_xoc256_2xopg128_clos_sh
   name: Training XOC-256 2x OPG-128 Clos SH
   description: Compute-only DIET translation for the XOC-256 (2x OPG-128) single-homed training RA
   version: 1

--- a/compositions/XOC-512/1x-OPG-512/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/netbox_inventory.json
+++ b/compositions/XOC-512/1x-OPG-512/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/netbox_inventory.json
@@ -58618,7 +58618,7 @@
     },
     "generated_at": "2026-03-14T05:11:16.396076+00:00",
     "plan_id": 68,
-    "plan_name": "Training XOC-512 1x OPG-512 Clos RO Air 2srv"
+    "plan_name": "Training XOC-512 1x OPG-512 Clos RO"
   },
   "modules": [
     {

--- a/compositions/XOC-512/1x-OPG-512/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/topology-map.yaml
+++ b/compositions/XOC-512/1x-OPG-512/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/topology-map.yaml
@@ -1,5 +1,5 @@
 meta:
-  case_id: training_xoc512_1xopg512_clos_ro_air_2srv
+  case_id: training_xoc512_1xopg512_clos_ro
   name: Training XOC-512 1x OPG-512 Clos RO
   description: Compute-only DIET translation for the OPG-512 rail-optimized training RA
   version: 1

--- a/compositions/XOC-512/1x-OPG-512/dual-plane--cx8-2x400g--bf3-2x200g--2p--storage-conv-2x200g/netbox_inventory.json
+++ b/compositions/XOC-512/1x-OPG-512/dual-plane--cx8-2x400g--bf3-2x200g--2p--storage-conv-2x200g/netbox_inventory.json
@@ -104682,7 +104682,7 @@
     },
     "generated_at": "2026-03-14T05:33:59.311552+00:00",
     "plan_id": 69,
-    "plan_name": "Training XOC-512 1x OPG-512 Dual Plane Air 2srv"
+    "plan_name": "Training XOC-512 1x OPG-512 Dual Plane"
   },
   "modules": [
     {

--- a/compositions/XOC-512/1x-OPG-512/dual-plane--cx8-2x400g--bf3-2x200g--2p--storage-conv-2x200g/topology-map.yaml
+++ b/compositions/XOC-512/1x-OPG-512/dual-plane--cx8-2x400g--bf3-2x200g--2p--storage-conv-2x200g/topology-map.yaml
@@ -1,5 +1,5 @@
 meta:
-  case_id: training_xoc512_1xopg512_dual_plane_air_2srv
+  case_id: training_xoc512_1xopg512_dual_plane
   name: Training XOC-512 1x OPG-512 Dual Plane
   description: Compute-only DIET translation for the OPG-512 dual-plane training RA
   version: 1

--- a/compositions/XOC-512/4x-OPG-128/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/netbox_inventory.json
+++ b/compositions/XOC-512/4x-OPG-128/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/netbox_inventory.json
@@ -58618,7 +58618,7 @@
     },
     "generated_at": "2026-03-14T06:36:31.057633+00:00",
     "plan_id": 72,
-    "plan_name": "Training XOC-512 4x OPG-128 Clos RO Air 2srv"
+    "plan_name": "Training XOC-512 4x OPG-128 Clos RO"
   },
   "modules": [
     {

--- a/compositions/XOC-512/4x-OPG-128/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/topology-map.yaml
+++ b/compositions/XOC-512/4x-OPG-128/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/topology-map.yaml
@@ -1,5 +1,5 @@
 meta:
-  case_id: training_xoc512_4xopg128_clos_ro_air_2srv
+  case_id: training_xoc512_4xopg128_clos_ro
   name: Training XOC-512 4x OPG-128 Clos RO
   description: Compute-only DIET translation for the OPG-512 rail-optimized training RA
   version: 1

--- a/compositions/XOC-512/4x-OPG-128/clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/netbox_inventory.json
+++ b/compositions/XOC-512/4x-OPG-128/clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/netbox_inventory.json
@@ -58618,7 +58618,7 @@
     },
     "generated_at": "2026-03-14T06:52:44.023134+00:00",
     "plan_id": 73,
-    "plan_name": "Training XOC-512 4x OPG-128 Clos SH Air 2srv"
+    "plan_name": "Training XOC-512 4x OPG-128 Clos SH"
   },
   "modules": [
     {

--- a/compositions/XOC-512/4x-OPG-128/clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/topology-map.yaml
+++ b/compositions/XOC-512/4x-OPG-128/clos-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/topology-map.yaml
@@ -1,5 +1,5 @@
 meta:
-  case_id: training_xoc512_4xopg128_clos_sh_air_2srv
+  case_id: training_xoc512_4xopg128_clos_sh
   name: Training XOC-512 4x OPG-128 Clos SH
   description: Compute-only DIET translation for the XOC-512 (4x OPG-128) single-homed training RA
   version: 1

--- a/compositions/XOC-64/1x-OPG-64/mesh-conv-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--inb-2x25g/generated/inputs/training_xoc64_1xopg64_mesh_conv_ro.yaml
+++ b/compositions/XOC-64/1x-OPG-64/mesh-conv-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--inb-2x25g/generated/inputs/training_xoc64_1xopg64_mesh_conv_ro.yaml
@@ -1,6 +1,6 @@
 meta:
-  case_id: training_xoc64_1xopg64_mesh_conv_ro_air_2srv
-  name: Training XOC-64 1x OPG-64 Mesh Converged RO Air 2srv
+  case_id: training_xoc64_1xopg64_mesh_conv_ro
+  name: Training XOC-64 1x OPG-64 Mesh Converged RO
   description: XOC-64 composition built from one OPG-64 mesh-converged training building block with rail-optimized scale-out
   version: 1
   managed_by: yaml
@@ -431,7 +431,7 @@ reference_data:
       model: OSFP-200G-DR4
 
 plan:
-  name: Training XOC-64 1x OPG-64 Mesh Converged RO Air 2srv
+  name: Training XOC-64 1x OPG-64 Mesh Converged RO
   status: draft
   description: >
     XOC-64 composition of one OPG-64 training building block. Scale-out and

--- a/compositions/XOC-64/1x-OPG-64/mesh-conv-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--inb-2x25g/generated/inputs/translation-notes.md
+++ b/compositions/XOC-64/1x-OPG-64/mesh-conv-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--inb-2x25g/generated/inputs/translation-notes.md
@@ -1,4 +1,4 @@
-# Translation Notes: training_xoc64_1xopg64_mesh_conv_ro_air_2srv
+# Translation Notes: training_xoc64_1xopg64_mesh_conv_ro
 
 ## Pass-1 Status: complete-pass1
 

--- a/compositions/XOC-64/1x-OPG-64/mesh-conv-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--inb-2x25g/generated/netbox/plan_inventory.json
+++ b/compositions/XOC-64/1x-OPG-64/mesh-conv-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--inb-2x25g/generated/netbox/plan_inventory.json
@@ -9561,7 +9561,7 @@
     },
     "generated_at": "2026-04-12T23:46:31.793389+00:00",
     "plan_id": 156,
-    "plan_name": "Training XOC-64 1x OPG-64 Mesh Converged RO Air 2srv"
+    "plan_name": "Training XOC-64 1x OPG-64 Mesh Converged RO"
   },
   "modules": [
     {

--- a/compositions/XOC-64/1x-OPG-64/mesh-conv-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--inb-2x25g/topology-map.yaml
+++ b/compositions/XOC-64/1x-OPG-64/mesh-conv-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--inb-2x25g/topology-map.yaml
@@ -1,5 +1,5 @@
 meta:
-  case_id: training_xoc64_1xopg64_mesh_conv_ro_air_2srv
+  case_id: training_xoc64_1xopg64_mesh_conv_ro
   name: Training XOC-64 1x OPG-64 Mesh Converged RO
   description: XOC-64 composition built from one OPG-64 mesh-converged training building block with rail-optimized scale-out
   version: 1

--- a/compositions/XOC-64/1x-OPG-64/mesh-conv-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--inb-2x25g/generated/inputs/training_xoc64_1xopg64_mesh_conv_sh.yaml
+++ b/compositions/XOC-64/1x-OPG-64/mesh-conv-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--inb-2x25g/generated/inputs/training_xoc64_1xopg64_mesh_conv_sh.yaml
@@ -1,6 +1,6 @@
 meta:
-  case_id: training_xoc64_1xopg64_mesh_conv_sh_air_2srv
-  name: Training XOC-64 1x OPG-64 Mesh Converged SH Air 2srv
+  case_id: training_xoc64_1xopg64_mesh_conv_sh
+  name: Training XOC-64 1x OPG-64 Mesh Converged SH
   description: XOC-64 composition built from one OPG-64 mesh-converged training building block with single-homed scale-out
   version: 1
   managed_by: yaml
@@ -431,7 +431,7 @@ reference_data:
       model: OSFP-200G-DR4
 
 plan:
-  name: Training XOC-64 1x OPG-64 Mesh Converged SH Air 2srv
+  name: Training XOC-64 1x OPG-64 Mesh Converged SH
   status: draft
   description: >
     XOC-64 composition of one OPG-64 training building block. Scale-out and

--- a/compositions/XOC-64/1x-OPG-64/mesh-conv-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--inb-2x25g/generated/inputs/translation-notes.md
+++ b/compositions/XOC-64/1x-OPG-64/mesh-conv-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--inb-2x25g/generated/inputs/translation-notes.md
@@ -1,4 +1,4 @@
-# Translation Notes: training_xoc64_1xopg64_mesh_conv_sh_air_2srv
+# Translation Notes: training_xoc64_1xopg64_mesh_conv_sh
 
 ## Pass-1 Status: complete-pass1
 

--- a/compositions/XOC-64/1x-OPG-64/mesh-conv-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--inb-2x25g/generated/netbox/plan_inventory.json
+++ b/compositions/XOC-64/1x-OPG-64/mesh-conv-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--inb-2x25g/generated/netbox/plan_inventory.json
@@ -9561,7 +9561,7 @@
     },
     "generated_at": "2026-04-12T23:51:10.993249+00:00",
     "plan_id": 157,
-    "plan_name": "Training XOC-64 1x OPG-64 Mesh Converged SH Air 2srv"
+    "plan_name": "Training XOC-64 1x OPG-64 Mesh Converged SH"
   },
   "modules": [
     {

--- a/compositions/XOC-64/1x-OPG-64/mesh-conv-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--inb-2x25g/topology-map.yaml
+++ b/compositions/XOC-64/1x-OPG-64/mesh-conv-sh--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--inb-2x25g/topology-map.yaml
@@ -1,5 +1,5 @@
 meta:
-  case_id: training_xoc64_1xopg64_mesh_conv_sh_air_2srv
+  case_id: training_xoc64_1xopg64_mesh_conv_sh
   name: Training XOC-64 1x OPG-64 Mesh Converged SH
   description: XOC-64 composition built from one OPG-64 mesh-converged training building block with single-homed scale-out
   version: 1

--- a/docs/COMPOSITION_VARIANT_NAMING_TAXONOMY.md
+++ b/docs/COMPOSITION_VARIANT_NAMING_TAXONOMY.md
@@ -12,7 +12,7 @@ Inputs/Constraints
 Deliverable
 - A short RFC (1–2 pages) with recommended patterns, examples, and mapping rules.
 
-Proposal v1.1 (adds density and storage flags)
+Proposal v1.1 (adds storage flags)
 - Goals: concise, human‑parsable, future‑proof; compatible with folder names; aligns with OCP terms.
 - Folder token format (ordered):
   <topo>--<so>--<fe>[--<planes>][--<storage>]
@@ -24,7 +24,7 @@ Proposal v1.1 (adds density and storage flags)
     - Examples: storage-conv-2x200g (frontend converged SO‑C/Storage 2×200G)
                storage-ded-2x100g (dedicated storage fabric 2×100G)
 
-Note on cooling and density
+Note on cooling
 - The compositions in this repository are designed to work with air or liquid cooling at any density. Cooling medium and rack density are physical deployment choices that do not affect the network topology and are not encoded in variant names.
 
 Examples

--- a/docs/TOPOLOGY_PLAN_YAML_REFERENCE.md
+++ b/docs/TOPOLOGY_PLAN_YAML_REFERENCE.md
@@ -558,8 +558,8 @@ Useful flags:
 - Current large regression case:
   - `netbox_hedgehog/test_cases/ux_case_128gpu_odd_ports.yaml`
 - Modern generated-plan cases:
-  - `netbox_hedgehog/test_cases/training_opg128_clos_ro_air_2srv.yaml`
-  - `netbox_hedgehog/test_cases/inference_opg64_clos_ro_air_2srv.yaml`
+  - `netbox_hedgehog/test_cases/training_opg128_clos_ro.yaml`
+  - `netbox_hedgehog/test_cases/inference_opg64_clos_ro.yaml`
 
 ## Important note
 


### PR DESCRIPTION
## Summary

- Strips `_air_2srv` from all 19 `case_id` fields in `topology-map.yaml` files
- Strips ` Air 2srv` from `plan_name` in all `netbox_inventory.json` and `plan_inventory.json` files
- Renames generated input yaml files (removes `_air_2srv` suffix) and updates internal references
- Removes density-specific rack-count line from OPG-256 `topology-overview.md`
- Updates `COMPOSITION_VARIANT_NAMING_TAXONOMY.md`: Proposal v1.1 header drops "density and"; section header "Note on cooling and density" → "Note on cooling"
- Updates `compositions/README.md` section header "Cooling and density" → "Cooling"
- Updates `docs/TOPOLOGY_PLAN_YAML_REFERENCE.md` example case_id filenames

**Cross-repo note:** The `case_id` renames require corresponding fixture file renames in `hh-netbox-plugin/netbox_hedgehog/test_cases/` and updates to `scripts/run_ra_pipeline.sh`.

## Test plan

- [ ] Grep confirms no remaining `_air_2srv`, `Air 2srv`, or `density and` in tracked files
- [ ] All topology-map.yaml case_id values match the new naming convention
- [ ] JSON inventory plan_name fields updated consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)